### PR TITLE
Release 3.0.1

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,5 +4,10 @@
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
-    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
+    <application
+        android:usesCleartextTraffic="true"
+        tools:targetApi="28"
+        tools:ignore="GoogleAppIndexingWarning"
+        tools:remove="android:networkSecurityConfig"
+    />
 </manifest>

--- a/ios/UniteAppRN/Info-DEV.plist
+++ b/ios/UniteAppRN/Info-DEV.plist
@@ -60,8 +60,6 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>We need your camera to scan QR codes</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Baloo-Black.ttf</string>

--- a/ios/UniteAppRN/Info-DEVOPS.plist
+++ b/ios/UniteAppRN/Info-DEVOPS.plist
@@ -60,8 +60,6 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>We need your camera to scan QR codes</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Baloo-Black.ttf</string>

--- a/ios/UniteAppRN/Info-ENF.plist
+++ b/ios/UniteAppRN/Info-ENF.plist
@@ -47,8 +47,6 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>We need your camera to scan QR codes</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Baloo-Black.ttf</string>
@@ -80,8 +78,6 @@
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
-		<string>bluetooth-le</string>
-		<string>telephony</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/ios/UniteAppRN/Info-TEST.plist
+++ b/ios/UniteAppRN/Info-TEST.plist
@@ -60,8 +60,6 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>We need your camera to scan QR codes</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Baloo-Black.ttf</string>

--- a/ios/UniteAppRN/Info-UAT.plist
+++ b/ios/UniteAppRN/Info-UAT.plist
@@ -60,8 +60,6 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>We need your camera to scan QR codes</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Baloo-Black.ttf</string>

--- a/ios/UniteAppRN/Info.plist
+++ b/ios/UniteAppRN/Info.plist
@@ -52,8 +52,6 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>We need your camera to scan QR codes</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Baloo-Black.ttf</string>
@@ -85,8 +83,6 @@
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
-		<string>bluetooth-le</string>
-		<string>telephony</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/setup.ts
+++ b/setup.ts
@@ -17,9 +17,11 @@ import { createLogger } from "@logger/createLogger";
 import messaging, {
   FirebaseMessagingTypes,
 } from "@react-native-firebase/messaging";
+import { Analytics } from "aws-amplify";
 import { dirname } from "path";
 import { AppState, AppStateStatus, Platform } from "react-native";
 import DeviceInfo from "react-native-device-info";
+import ExposureNotificationModule from "react-native-exposure-notification-service";
 import { enableScreens } from "react-native-screens";
 
 import { configure as configurePush } from "./src/notifications";
@@ -94,4 +96,23 @@ logInfo(`app state ${AppState.currentState}`);
 
 AppState.addEventListener("change", (value: AppStateStatus) => {
   logInfo(`app state ${value}`);
+});
+
+AppState.addEventListener("change", (value) => {
+  if (value === "active") {
+    ExposureNotificationModule.exposureEnabled()
+      .then((isENFEnabled) => {
+        logInfo(
+          "Update isENFEnabled via Analytics.updateEndpoint with value: " +
+            isENFEnabled,
+        );
+
+        return Analytics.updateEndpoint({
+          attributes: {
+            isENFEnabled: [isENFEnabled],
+          },
+        });
+      })
+      .catch(logError);
+  }
 });

--- a/src/HeadlessCheck.tsx
+++ b/src/HeadlessCheck.tsx
@@ -1,3 +1,4 @@
+import { SplashScreen } from "@features/onboarding/views/SplashScreen";
 import { createLogger } from "@logger/createLogger";
 import { useAppState } from "@react-native-community/hooks";
 import React, { useEffect, useState } from "react";
@@ -25,13 +26,13 @@ export function HeadlessCheck({ isHeadless, isBackground }: Prop) {
   if (isHeadless) {
     // App has been launched in the background by iOS, ignore
     logInfo("is headless, ignore");
-    return null;
+    return <SplashScreen />;
   }
 
   if (!beenActive) {
     // App has been launched in the background by iOS, ignore
     logInfo("app is not active, ignore");
-    return null;
+    return <SplashScreen />;
   }
 
   return <App />;

--- a/src/features/enfExposure/events.ts
+++ b/src/features/enfExposure/events.ts
@@ -13,6 +13,7 @@ export const ENFEvent = {
   ENFEnableSuccess: "enfEnableSuccess",
   ENFDisableButtonPressed: "enfDisableButtonPressed",
   ENFDisableModalPressed: "enfDisableModalPressed",
+  ENFOnboardingEnableSuccess: "enfOnboardingEnableSuccess",
 } as const;
 
 export type ENFEventPayloads = {

--- a/src/features/onboarding/reducer.spec.ts
+++ b/src/features/onboarding/reducer.spec.ts
@@ -2,7 +2,6 @@ import { setCountedOldDiaries } from "@features/diary/commonActions";
 import {
   registerDeviceFulfilled,
   registerDeviceRejected,
-  registerDeviceSkipped,
 } from "@features/verification/commonActions";
 import { nanoid } from "@reduxjs/toolkit";
 
@@ -130,7 +129,6 @@ describe("#registerDevice", () => {
   const cases = [
     ["failure", registerDeviceFulfilled.type, "retrySuccess"],
     [undefined, registerDeviceFulfilled.type, "success"],
-    [undefined, registerDeviceSkipped.type, "skipped"],
     [undefined, registerDeviceRejected.type, "failure"],
   ];
 
@@ -142,9 +140,6 @@ describe("#registerDevice", () => {
           token: nanoid(),
           refreshToken: nanoid(),
         });
-        break;
-      case registerDeviceSkipped.type:
-        action = registerDeviceSkipped();
         break;
       case registerDeviceRejected.type:
         action = registerDeviceRejected({ isNetworkError: false });

--- a/src/features/onboarding/reducer.ts
+++ b/src/features/onboarding/reducer.ts
@@ -2,7 +2,6 @@ import { setCountedOldDiaries } from "@features/diary/commonActions";
 import {
   registerDeviceFulfilled,
   registerDeviceRejected,
-  registerDeviceSkipped,
 } from "@features/verification/commonActions";
 import { createLogger } from "@logger/createLogger";
 import { createSlice, Draft, PayloadAction } from "@reduxjs/toolkit";
@@ -225,10 +224,6 @@ const slice = createSlice({
             state.deviceRegistered = "success";
             break;
         }
-        reduceIsLoading(state);
-      })
-      .addCase(registerDeviceSkipped, (state) => {
-        state.deviceRegistered = "skipped";
         reduceIsLoading(state);
       })
       .addCase(registerDeviceRejected, (state, _action) => {

--- a/src/features/onboarding/views/EnableENF.tsx
+++ b/src/features/onboarding/views/EnableENF.tsx
@@ -7,6 +7,7 @@ import {
   fontSizes,
   grid2x,
 } from "@constants";
+import { ENFEvent } from "@features/enfExposure/events";
 import { isIOS } from "@lib/helpers";
 import { createLogger } from "@logger/createLogger";
 import { useAccessibleTitle } from "@navigation/hooks/useAccessibleTitle";
@@ -20,6 +21,7 @@ import {
 } from "react-native-exposure-notification-service";
 import styled from "styled-components";
 
+import { recordAnalyticEvent } from "../../../analytics";
 import { OnboardingScreen } from "../screens";
 import { styles } from "../styles";
 import { useOnboardingFlow } from "../useOnboardingFlow";
@@ -103,6 +105,9 @@ export function EnableENF(props: Props) {
 
     try {
       const authorised = await authoriseExposure();
+      if (authorised) {
+        recordAnalyticEvent(ENFEvent.ENFOnboardingEnableSuccess);
+      }
       await readPermissions();
 
       logInfo("Attempt to authoriseExposure" + authorised);

--- a/src/features/scan/views/Scan.tsx
+++ b/src/features/scan/views/Scan.tsx
@@ -15,6 +15,7 @@ import { useAppDispatch } from "@lib/useAppDispatch";
 import { createLogger } from "@logger/createLogger";
 import { BarcodeMask } from "@nartc/react-native-barcode-mask";
 import { useAccessibleTitle } from "@navigation/hooks/useAccessibleTitle";
+import { useAppState } from "@react-native-community/hooks";
 import { useFocusEffect, useIsFocused } from "@react-navigation/native";
 import { StackScreenProps } from "@react-navigation/stack";
 import { nanoid, unwrapResult } from "@reduxjs/toolkit";
@@ -201,6 +202,7 @@ export function Scan(props: Props) {
 
   useEffect(() => {
     if (!isCameraMounted && isFocused) {
+      logInfo("remount camera");
       setIsCameraMounted(true);
       return;
     }
@@ -209,6 +211,7 @@ export function Scan(props: Props) {
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       if (!isFocused) {
+        logInfo("unmount camera");
         setIsCameraMounted(false);
       }
     }, TIME_TO_UNMOUNT_CAMERA_AFTER);
@@ -372,6 +375,24 @@ export function Scan(props: Props) {
     () => isCameraMounted && cameraPermission === "granted",
     [isCameraMounted, cameraPermission],
   );
+
+  const appState = useAppState();
+
+  useEffect(() => {
+    if (cameraRef.current == null) {
+      return;
+    }
+    switch (appState) {
+      case "background":
+        logInfo("pause preview");
+        cameraRef.current.pausePreview();
+        break;
+      case "active":
+        logInfo("resume preview");
+        cameraRef.current.resumePreview();
+        break;
+    }
+  }, [appState]);
 
   useAccessibleTitle();
 

--- a/src/features/verification/commonActions.ts
+++ b/src/features/verification/commonActions.ts
@@ -17,10 +17,6 @@ export const registerDeviceRejected = createAction<RegisterDeviceRejected>(
   "verfication/registerDeviceRejected",
 );
 
-export const registerDeviceSkipped = createAction(
-  "verification/registerDeviceSkipped",
-);
-
 export const setEnfEnabled = createAction<boolean>(
   "verification/setEnfEnabled",
 );

--- a/src/views/ModalStack.tsx
+++ b/src/views/ModalStack.tsx
@@ -24,6 +24,7 @@ import messaging, {
 import { createStackNavigator } from "@react-navigation/stack";
 import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useExposure } from "react-native-exposure-notification-service";
 import SplashScreen from "react-native-splash-screen";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -67,13 +68,15 @@ export function ModalStack() {
   const enfEnableNotificationSent = useSelector(
     selectEnfEnableNotificationSent,
   );
+  const { supported: enfSupported } = useExposure();
 
   useEffect(() => {
     if (
       !enfEnableNotificationSent &&
       hasOnboarded &&
       !hasSeenEnf &&
-      deviceRegistered === "success"
+      deviceRegistered === "success" &&
+      enfSupported
     ) {
       notifyRegisterDeviceRetrySuccess()
         .then(() => {
@@ -90,6 +93,7 @@ export function ModalStack() {
     deviceRegistered,
     enfEnableNotificationSent,
     dispatch,
+    enfSupported,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
This PR contains fixes for the following:
- Logic errors during onboarding that was causing delays for device attestation on Android
- Prevent the camera from running when the scan tab is inactive to reduce battery consumption on some devices
- Show the splash screen when returning from suspended state on iOS
- Add additional analytics event for whether EN is enabled or not, and properly track EN activation during onboarding